### PR TITLE
make value_ref_* properties editable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 2024-02-24 Jan Kotanski <jankotan@gmail.com>
+	* make value_ref_* properfies editable  (#106)
+	* tagged as 3.22.0
+
+2024-02-24 Jan Kotanski <jankotan@gmail.com>
 	* add channel output combobox (#106)
 	* tagged as 3.21.0
 

--- a/nxsselector/LDataDlg.py
+++ b/nxsselector/LDataDlg.py
@@ -67,13 +67,18 @@ class LDataDlg(Qt.QDialog):
         self.link = None
         #: (:obj:`bool`) if spock scan output should be shown
         self.output = None
+        #: (:obj:`bool`) if value reference eneabled
+        self.refenabled = None
+        #: (:obj:`str`) value reference pattern
+        self.refpattern = ''
         #: (:obj:`bool`) if ds switched to CanFail mode
         self.canfail = None
         #: (:obj:`list` <:obj:`str` > ) available variable names
         self.available_names = None
         #: (:obj:`list` <:obj:`str` > ) special variable names
         self.special = ["shape", "data_type", "nexus_path", "canfail",
-                        "link", "output"]
+                        "link", "output",
+                        "value_ref_enabled", "value_ref_pattern"]
         #: (:obj:`dict` <:obj:`str` , :obj:`str` or :obj:`unicode`> ) \
         #:     (name, value) variable dictionary
         self.variables = {}
@@ -124,6 +129,22 @@ class LDataDlg(Qt.QDialog):
         return "Default"
 
     @classmethod
+    def __refenabledText(cls, value):
+        """ converts refenabled value to string, i.e. True, False or Default
+
+        :param value: refenabled value
+        :type value: :obj:`bool` or `None`
+        :returns: True, False or Default
+        :rtype: :obj:`str`
+        """
+        if isinstance(value, bool):
+            if value is True:
+                return "True"
+            if value is False:
+                return "False"
+        return "Default"
+
+    @classmethod
     def __canfailText(cls, value):
         """ converts canfail value to string, i.e. True, Default
 
@@ -146,6 +167,7 @@ class LDataDlg(Qt.QDialog):
         self.ui.synchronizerLabel.hide()
         self.ui.labelLineEdit.setText(str(str(self.label or "")))
         self.ui.pathLineEdit.setText(str(str(self.path or "")))
+        self.ui.refpatternLineEdit.setText(str(str(self.refpattern or "")))
         if self.shape is None:
             shape = ''
         else:
@@ -165,6 +187,12 @@ class LDataDlg(Qt.QDialog):
         if cid < 0:
             cid = 0
         self.ui.outputComboBox.setCurrentIndex(cid)
+
+        cid = self.ui.refenabledComboBox.findText(
+            str(self.__refenabledText(self.refenabled)))
+        if cid < 0:
+            cid = 0
+        self.ui.refenabledComboBox.setCurrentIndex(cid)
 
         cid = self.ui.canfailComboBox.findText(
             str(self.__canfailText(self.canfail)))
@@ -234,6 +262,14 @@ class LDataDlg(Qt.QDialog):
         else:
             self.output = None
 
+        refenabled = str(self.ui.refenabledComboBox.currentText())
+        if refenabled == "True":
+            self.refenabled = True
+        elif refenabled == "False":
+            self.refenabled = False
+        else:
+            self.refenabled = None
+
         canfail = str(self.ui.canfailComboBox.currentText())
         if canfail == "True":
             self.canfail = True
@@ -242,6 +278,7 @@ class LDataDlg(Qt.QDialog):
 
         self.label = unicode(self.ui.labelLineEdit.text())
         self.path = unicode(self.ui.pathLineEdit.text())
+        self.refpattern = unicode(self.ui.refpatternLineEdit.text())
         self.dtype = unicode(self.ui.typeLineEdit.text())
         tshape = unicode(self.ui.shapeLineEdit.text()).replace("None", "null")
         try:

--- a/nxsselector/PropertiesDlg.py
+++ b/nxsselector/PropertiesDlg.py
@@ -99,6 +99,12 @@ class PropertiesWg(Qt.QWidget):
         #:    property (name, output) dictionary
         self.outputs = {}
         #: (:obj:`dict` <:obj:`str`, :obj:`bool`>) \
+        #:    property (name, refenabled) dictionary
+        self.refenableds = {}
+        #: (:obj:`dict` <:obj:`str`, :obj:`str`>) \
+        #:    property (name, refpattern) dictionary
+        self.refpatterns = {}
+        #: (:obj:`dict` <:obj:`str`, :obj:`bool`>) \
         #:    property (name, canfailflag) dictionary
         self.canfailflags = {}
         #: (:obj:`dict` <:obj:`str`, :obj:`str`>) \
@@ -141,6 +147,8 @@ class PropertiesWg(Qt.QWidget):
                       set(self.links.keys()) |
                       set(self.canfailflags.keys()) |
                       set(self.outputs.keys()) |
+                      set(self.refenableds.keys()) |
+                      set(self.refpatterns.keys()) |
                       set(self.types.keys()))
 
     def __populateTable(self, selected=None):
@@ -155,7 +163,8 @@ class PropertiesWg(Qt.QWidget):
         names = self.__names()
         self.ui.tableWidget.setRowCount(len(names))
         headers = ["Name", "Type", "Shape",
-                   "Output", "Link", "CanFail", "Path"]
+                   "Output", "Link", "CanFail", "Path",
+                   "RefEnabled", "RefPattern"]
         self.ui.tableWidget.setColumnCount(len(headers))
         self.ui.tableWidget.setHorizontalHeaderLabels(headers)
         for row, name in enumerate(names):
@@ -191,6 +200,12 @@ class PropertiesWg(Qt.QWidget):
             value = str(self.paths[name]) \
                 if name in self.paths.keys() else ''
             self.ui.tableWidget.setItem(row, 6, Qt.QTableWidgetItem(value))
+            value = str(self.refenableds[name]) \
+                if name in self.refenableds.keys() else ''
+            self.ui.tableWidget.setItem(row, 7, Qt.QTableWidgetItem(value))
+            value = str(self.refpatterns[name]) \
+                if name in self.refpatterns.keys() else ''
+            self.ui.tableWidget.setItem(row, 8, Qt.QTableWidgetItem(value))
         self.ui.tableWidget.resizeColumnsToContents()
         self.ui.tableWidget.setSelectionBehavior(
             Qt.QAbstractItemView.SelectRows)
@@ -247,6 +262,7 @@ class PropertiesWg(Qt.QWidget):
             self.__updateItem(name, form.path, self.paths)
             self.__updateItem(name, form.dtype, self.types)
             self.__updateItem(name, form.shape, self.shapes)
+            self.__updateItem(name, form.refpattern, self.refpatterns)
 
             if form.link is None:
                 if name in self.links.keys():
@@ -259,6 +275,12 @@ class PropertiesWg(Qt.QWidget):
                     self.outputs.pop(name)
             elif name:
                 self.outputs[name] = form.output
+
+            if form.refenabled is None:
+                if name in self.refenableds.keys():
+                    self.refenableds.pop(name)
+            elif name:
+                self.refenableds[name] = form.refenabled
 
             if form.canfail is None:
                 if name in self.canfailflags.keys():
@@ -292,10 +314,14 @@ class PropertiesWg(Qt.QWidget):
             dform.link = self.links[name]
         if name in self.outputs.keys():
             dform.output = self.outputs[name]
+        if name in self.refenableds.keys():
+            dform.refenabled = self.refenableds[name]
         if name in self.canfailflags.keys():
             dform.canfail = self.canfailflags[name]
         if name in self.paths.keys():
             dform.path = self.paths[name]
+        if name in self.refpatterns.keys():
+            dform.refpattern = self.refpatterns[name]
 
         dform.available_names = self.available_names
         dform.createGUI()
@@ -323,10 +349,14 @@ class PropertiesWg(Qt.QWidget):
             self.links.pop(name)
         if name in self.outputs.keys():
             self.outputs.pop(name)
+        if name in self.refenableds.keys():
+            self.refenableds.pop(name)
         if name in self.canfailflags.keys():
             self.canfailflags.pop(name)
         if name in self.paths.keys():
             self.paths.pop(name)
+        if name in self.refpatterns.keys():
+            self.refpatterns.pop(name)
 
         self.dirty.emit()
         self.__populateTable()

--- a/nxsselector/ServerState.py
+++ b/nxsselector/ServerState.py
@@ -315,10 +315,14 @@ class ServerState(Qt.QObject):
         self.labellinks = {}
         #: (:obj:`dict` <:obj:`str` , :obj:`bool`>) label outputs
         self.labeloutputs = {}
+        #: (:obj:`dict` <:obj:`str` , :obj:`bool`>) label ref enabled flags
+        self.labelrefenableds = {}
         #: (:obj:`dict` <:obj:`str` , :obj:`bool`>) label canfail flags
         self.labelcanfailflags = {}
         #: (:obj:`dict` <:obj:`str` , :obj:`str`>) label nexus paths
         self.labelpaths = {}
+        #: (:obj:`dict` <:obj:`str` , :obj:`str`>) label ref pattern
+        self.labelrefpatterns = {}
         #: (:obj:`dict` <:obj:`str` , :obj:`list`< :obj:`int`> >) \
         #:     label data shapes
         self.labelshapes = {}
@@ -347,7 +351,8 @@ class ServerState(Qt.QObject):
                                'filename'
                                ]
         self.channelprops = ["nexus_path", "link", "shape", "label",
-                             "data_type", "canfail", "output"]
+                             "data_type", "canfail", "output",
+                             "value_ref_enabled", "value_ref_pattern"]
         self.extrachannelprops = ["synchronizer", "synchronization"]
         self.synchthread = SynchThread(self, self.server, self.mutex)
 
@@ -474,6 +479,10 @@ class ServerState(Qt.QObject):
             self.labeloutputs = self.properties["output"]
         else:
             self.labeloutputs = {}
+        if "value_ref_enabled" in self.properties:
+            self.labelrefenableds = self.properties["vale_ref_enabled"]
+        else:
+            self.labelrefenableds = {}
         if "canfail" in self.properties:
             self.labelcanfailflags = self.properties["canfail"]
         else:
@@ -482,6 +491,10 @@ class ServerState(Qt.QObject):
             self.labelpaths = self.properties["nexus_path"]
         else:
             self.labelpaths = {}
+        if "value_ref_pattern" in self.properties:
+            self.labelrefpatterns = self.properties["value_ref_pattern"]
+        else:
+            self.labelrefpatterns = {}
         if "shape" in self.properties:
             self.labelshapes = self.properties["shape"]
         else:
@@ -506,6 +519,8 @@ class ServerState(Qt.QObject):
         self.properties["label"] = self.labels
         self.properties["link"] = self.labellinks
         self.properties["output"] = self.labeloutputs
+        self.properties["value_ref_enabled"] = self.labelrefenableds
+        self.properties["value_ref_pattern"] = self.labelrefpatterns
         self.properties["canfail"] = self.labelcanfailflags
         self.properties["nexus_path"] = self.labelpaths
         self.properties["shape"] = self.labelshapes

--- a/nxsselector/Views.py
+++ b/nxsselector/Views.py
@@ -684,6 +684,10 @@ class CheckPropView(CheckDisView):
             dform.path = prs["nexus_path"] if "nexus_path" in prs else None
             dform.canfail = prs["canfail"] if "canfail" in prs else None
             dform.output = prs["output"] if "output" in prs else None
+            dform.refenabled = prs["value_ref_enabled"] \
+                if "value_ref_enabled" in prs else None
+            dform.refpattern = prs["value_ref_pattern"] \
+                if "value_ref_pattern" in prs else None
             dform.addVariables(prs)
             dform.createGUI()
 
@@ -696,6 +700,8 @@ class CheckPropView(CheckDisView):
                 prs["shape"] = dform.shape
                 prs["nexus_path"] = dform.path or None
                 prs["output"] = dform.output
+                prs["value_ref_enabled"] = dform.refenabled
+                prs["value_ref_pattern"] = dform.pattern
                 for nm, val in dform.variables.items():
                     prs[nm] = val
                 self.model.setData(ind5, (

--- a/nxsselector/__init__.py
+++ b/nxsselector/__init__.py
@@ -22,4 +22,4 @@ GUI for setting Sardana NeXus Recorder
 """
 
 #: (:obj:`str`) version of the application
-__version__ = "3.21.0"
+__version__ = "3.22.0"

--- a/nxsselector/ui/LDataDlg.ui
+++ b/nxsselector/ui/LDataDlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>328</width>
-    <height>384</height>
+    <width>406</width>
+    <height>480</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -78,6 +78,36 @@
         </property>
         <item>
          <layout class="QGridLayout" name="gridLayout">
+          <item row="4" column="0">
+           <widget class="QLabel" name="linkLabel">
+            <property name="text">
+             <string>&amp;Link:</string>
+            </property>
+            <property name="buddy">
+             <cstring>linkComboBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="synchronizationLabel">
+            <property name="text">
+             <string>Synchronization:</string>
+            </property>
+            <property name="buddy">
+             <cstring>synchronizationComboBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="canfailLabel">
+            <property name="text">
+             <string>CanFail:</string>
+            </property>
+            <property name="buddy">
+             <cstring>canfailComboBox</cstring>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="0">
            <widget class="QLabel" name="shapeLabel">
             <property name="text">
@@ -86,6 +116,18 @@
             <property name="buddy">
              <cstring>shapeLineEdit</cstring>
             </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QComboBox" name="synchronizerComboBox">
+            <property name="editable">
+             <bool>false</bool>
+            </property>
+            <item>
+             <property name="text">
+              <string>software</string>
+             </property>
+            </item>
            </widget>
           </item>
           <item row="6" column="1">
@@ -107,92 +149,6 @@
             </item>
            </widget>
           </item>
-          <item row="5" column="1">
-           <widget class="QComboBox" name="canfailComboBox">
-            <item>
-             <property name="text">
-              <string>Default</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>True</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="shapeLineEdit">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="linkLabel">
-            <property name="text">
-             <string>&amp;Link:</string>
-            </property>
-            <property name="buddy">
-             <cstring>linkComboBox</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="synchronizerLabel">
-            <property name="text">
-             <string>Synchronizer:</string>
-            </property>
-            <property name="buddy">
-             <cstring>synchronizerComboBox</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="canfailLabel">
-            <property name="text">
-             <string>CanFail:</string>
-            </property>
-            <property name="buddy">
-             <cstring>canfailComboBox</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="1">
-           <widget class="QComboBox" name="synchronizerComboBox">
-            <property name="editable">
-             <bool>false</bool>
-            </property>
-            <item>
-             <property name="text">
-              <string>software</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="typeLabel">
-            <property name="text">
-             <string>&amp;Type:</string>
-            </property>
-            <property name="buddy">
-             <cstring>typeLineEdit</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="synchronizationLabel">
-            <property name="text">
-             <string>Synchronization:</string>
-            </property>
-            <property name="buddy">
-             <cstring>synchronizationComboBox</cstring>
-            </property>
-           </widget>
-          </item>
           <item row="4" column="1">
            <widget class="QComboBox" name="linkComboBox">
             <item>
@@ -212,19 +168,13 @@
             </item>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="typeLineEdit"/>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="outputLabel">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show channel in the spock scan output&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
+          <item row="7" column="0">
+           <widget class="QLabel" name="synchronizerLabel">
             <property name="text">
-             <string>Output:</string>
+             <string>Synchronizer:</string>
             </property>
             <property name="buddy">
-             <cstring>outputComboBox</cstring>
+             <cstring>synchronizerComboBox</cstring>
             </property>
            </widget>
           </item>
@@ -250,7 +200,112 @@
             </item>
            </widget>
           </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="shapeLineEdit">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="typeLineEdit"/>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="outputLabel">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show channel in the spock scan output&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Output:</string>
+            </property>
+            <property name="buddy">
+             <cstring>outputComboBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QComboBox" name="canfailComboBox">
+            <item>
+             <property name="text">
+              <string>Default</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>True</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="typeLabel">
+            <property name="text">
+             <string>&amp;Type:</string>
+            </property>
+            <property name="buddy">
+             <cstring>typeLineEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="refeneabledLabel">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable channel  value reference &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>ValueRefEnabled:</string>
+            </property>
+            <property name="buddy">
+             <cstring>refeneabledComboBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QComboBox" name="refeneabledComboBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable channel  value reference &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>Default</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>True</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>False</string>
+             </property>
+            </item>
+           </widget>
+          </item>
          </layout>
+        </item>
+        <item>
+         <widget class="QLabel" name="refpatternLabel">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;value reference pattern of the channel&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>ValueRefPattern:</string>
+          </property>
+          <property name="buddy">
+           <cstring>refpatternLineEdit</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="refpatternLineEdit">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;value reference pattern of the channel&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
         </item>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout">
@@ -279,6 +334,8 @@
        <zorder></zorder>
        <zorder></zorder>
        <zorder>pathLineEdit</zorder>
+       <zorder>refpatternLabel</zorder>
+       <zorder>refpatternLineEdit</zorder>
       </widget>
      </item>
      <item>
@@ -348,6 +405,8 @@
   <tabstop>canfailComboBox</tabstop>
   <tabstop>synchronizationComboBox</tabstop>
   <tabstop>synchronizerComboBox</tabstop>
+  <tabstop>refeneabledComboBox</tabstop>
+  <tabstop>refpatternLineEdit</tabstop>
   <tabstop>pathLineEdit</tabstop>
  </tabstops>
  <resources/>
@@ -359,8 +418,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>238</x>
-     <y>337</y>
+     <x>248</x>
+     <y>378</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -375,8 +434,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>306</x>
-     <y>337</y>
+     <x>316</x>
+     <y>378</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>


### PR DESCRIPTION
It resolves #76 by making  value_ref_* properties editable. Currently value_ref_* and not used by NXS_FileRecorder and NXSDataWriter but it can be used by other recorders.